### PR TITLE
feat: add minimal ai-review workflow

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -1,0 +1,42 @@
+name: ai-review
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  ai-review:
+    if: >-
+      github.event.issue.pull_request != null &&
+      startsWith(github.event.comment.body, '/run-claude review')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post review stub comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issue_number = context.payload.issue.number;
+
+            const body = [
+              "`/run-claude review` を受け付けました（最小版）。",
+              "",
+              "次フェーズで、以下を自動化していきます：",
+              "- PR差分の観点チェック",
+              "- PR本文（AC→Test）の整合チェック",
+              "- リスク/不足観点のコメント化",
+              "",
+              "現時点では review 実行の器（起動・応答）まで実装済みです。",
+            ].join("\n");
+
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number,
+              body,
+            });


### PR DESCRIPTION
## Summary
- add .github/workflows/ai-review.yml
- trigger on issue comment /run-claude review
- post review stub response comment as minimal entrypoint

## Scope
- workflow scaffold only
- no real reviewer agent execution yet