### PR TITLE
docs: add Claude comment command guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,29 @@
 | `phase-stable`    | 安定運用フェーズ（デフォルト）               |
 | `allow-deps`      | 依存ファイル変更の例外許可（Soft Gate解除）  |
 | `allow-config`    | 設定ファイル変更の例外許可（Soft Gate解除）  |
+
+## Claudeコメントコマンド運用（最小）
+
+### 前提
+
+- 対象Issueに `ai-ready` ラベルが付いていること
+- `ai-question` / `ai-blocked` が付いていないこと
+
+### 使い方
+
+1. **計画（read-only）**
+   - Issueコメントで `/run-claude plan`
+   - `ai-plan.yml` が起動し、最小版コメントを返します
+
+2. **実装（最小版の器）**
+   - Issueコメントで `/run-claude implement`
+   - `ai-implement.yml` が起動し、最小版コメントを返します
+
+3. **レビュー（最小版の器）**
+   - PRコメントで `/run-claude review`
+   - `ai-review.yml` が起動し、最小版コメントを返します
+
+### マージ方針
+
+- 本テンプレートは **手動マージ運用** です
+- required checks（`ci` / `policy-gate`）が成功したPRを、人間が確認してマージします


### PR DESCRIPTION
## Summary
- add README section for Claude comment command operations
- document prerequisites (, no  / )
- document  entrypoints
- clarify manual merge policy

## Scope
- README.md only