### PR TITLE
fix: make allowed_files bypass soft_gate checks

### DIFF
--- a/.claude/operational-challenges.md
+++ b/.claude/operational-challenges.md
@@ -125,4 +125,15 @@
 
 ---
 
+## E. 第2回リポジトリレビュー（2026-02-20）
+
+### E-4. `allowed_files` が soft_gate チェックをバイパスしない【低】 ✅ 対応済み（2026-02-20 / `fix/e4-allowed-files-bypass-soft-gate`）
+
+- **対象**: `tools/policy-gate.js` L306-314（hard_gate）vs L331-343（soft_gate）
+- **現象**: `allowed_files` は hard_gate の除外に使われるが、soft_gate チェックでは考慮されない
+- **影響**: `allowed_files` に入れたファイルでも soft_gate が発動するため、運用者に混乱を与える
+- **対処**: soft_gate チェックでも `allowed_files` を除外対象に追加し、テストケースを追加
+
+---
+
 > 最終更新: 2026-02-20

--- a/tools/policy-gate.js
+++ b/tools/policy-gate.js
@@ -329,11 +329,13 @@ function main() {
   const allowConfig = args.allowConfig || process.env.ALLOW_CONFIG === 'true';
 
   const depsHits = (softGate.deps || []).length
-    ? changes.filter((c) => changeMatches(softGate.deps, c)).map((c) => c.path)
+    ? changes
+        .filter((c) => changeMatches(softGate.deps, c) && !allowedFiles.includes(c.path))
+        .map((c) => c.path)
     : [];
   const configHits = (softGate.config || []).length
     ? changes
-        .filter((c) => changeMatches(softGate.config, c))
+        .filter((c) => changeMatches(softGate.config, c) && !allowedFiles.includes(c.path))
         .map((c) => c.path)
     : [];
 


### PR DESCRIPTION
## Summary
- `policy-gate.js` の soft_gate チェックで `allowed_files` を除外対象に追加
- hard_gate と同様に、`allowed_files` に明示されたファイルは soft_gate を通過するように統一
- テストケースを追加（`allowed_files` バイパス、soft gate ブロック/許可の3パターン）

## Test plan
- [x] `node --test tools/policy-gate.test.js` 全6テスト通過確認済み
  - `allowed_files bypasses soft gate without allow flag` (新規)
  - `soft gate blocks deps file without allow flag` (修正: `tools/deps.lock` 使用)
  - `soft gate allows deps file with ALLOW_DEPS=true` (修正)

🤖 Generated with [Claude Code](https://claude.com/claude-code)